### PR TITLE
fix: corsConfigurationSrouce()

### DIFF
--- a/src/main/kotlin/com/example/powerclean/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/powerclean/config/SecurityConfig.kt
@@ -55,7 +55,7 @@ class SecurityConfig {
 
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
-        configuration.allowedOriginPatterns =
+        configuration.allowedOrigins =
             listOf(
                 "http://127.0.0.1:3000",
                 "http://localhost:3000",


### PR DESCRIPTION
configuration.allowCredentials = true 로 세팅 시 정규식 적용이 안됨에 따라 
allowedOriginPatterns -> allowedOrigins로 수정.